### PR TITLE
Disable 2FA for MFTF

### DIFF
--- a/Test/Mftf/ActionGroup/AdminLoginActionGroup.xml
+++ b/Test/Mftf/ActionGroup/AdminLoginActionGroup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminLoginActionGroup">
+        <helper class="MarkShust\DisableTwoFactorAuth\Test\Mftf\Helper\SetSharedSecretOverride" method="execute" stepKey="setSharedSecret" before="clickLogin">
+            <argument name="username">{{username}}</argument>
+        </helper>
+        <helper class="MarkShust\DisableTwoFactorAuth\Test\Mftf\Helper\FillOtpOverride" method="execute" stepKey="fillOtp" before="clickDontAllowButtonIfVisible">
+            <argument name="tfaAuthCodeSelector">{{AdminGoogleTfaSection.tfaAuthCode}}</argument>
+            <argument name="confirmSelector">{{AdminGoogleTfaSection.confirm}}</argument>
+            <argument name="errorMessageSelector">{{AdminLoginMessagesSection.messageByType('error')}}</argument>
+        </helper>
+    </actionGroup>
+</actionGroups>

--- a/Test/Mftf/Helper/FillOtpOverride.php
+++ b/Test/Mftf/Helper/FillOtpOverride.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkShust\DisableTwoFactorAuth\Test\Mftf\Helper;
+
+use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
+use Magento\FunctionalTestingFramework\Helper\Helper;
+use Magento\FunctionalTestingFramework\Module\MagentoWebDriver;
+
+class FillOtpOverride extends Helper
+{
+    /**
+     * Fill the OTP form if appropriate
+     *
+     * @param string $tfaAuthCodeSelector
+     * @param string $confirmSelector
+     * @param string $errorMessageSelector
+     */
+    public function execute(string $tfaAuthCodeSelector, string $confirmSelector, string $errorMessageSelector): void
+    {
+        /** @var MagentoWebDriver $webDriver */
+        $webDriver = $this->getModule('\\' . MagentoWebDriver::class);
+        if (!$this->checkIfTwoFactorIsEnabled($webDriver)) {
+            return;
+        }
+        try {
+            $webDriver->seeElementInDOM($errorMessageSelector);
+            // Login failed so don't handle 2fa
+        } catch (\Exception $e) {
+            $otp = $webDriver->getOTP();
+            $webDriver->waitForPageLoad();
+            $webDriver->waitForElementVisible($tfaAuthCodeSelector);
+            $webDriver->fillField($tfaAuthCodeSelector, $otp);
+            $webDriver->click($confirmSelector);
+            $webDriver->waitForPageLoad();
+        }
+    }
+
+    /**
+     * @param MagentoWebDriver $webDriver
+     */
+    private function checkIfTwoFactorIsEnabled(MagentoWebDriver $webDriver): bool
+    {
+        try {
+            $tfaEnabled = (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
+        } catch (TestFrameworkException $exception) {
+            $tfaEnabled = false;
+        }
+    }
+}

--- a/Test/Mftf/Helper/FillOtpOverride.php
+++ b/Test/Mftf/Helper/FillOtpOverride.php
@@ -43,13 +43,11 @@ class FillOtpOverride extends Helper
     private function checkIfTwoFactorIsEnabled(MagentoWebDriver $webDriver): bool
     {
         try {
-            $tfaEnabled = (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
+            return (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
         } catch (TestFrameworkException $exception) {
-            $tfaEnabled = false;
 
-            return $tfaEnabled;
+            return false;
         }
 
-        return true;
     }
 }

--- a/Test/Mftf/Helper/FillOtpOverride.php
+++ b/Test/Mftf/Helper/FillOtpOverride.php
@@ -46,6 +46,10 @@ class FillOtpOverride extends Helper
             $tfaEnabled = (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
         } catch (TestFrameworkException $exception) {
             $tfaEnabled = false;
+
+            return $tfaEnabled;
         }
+
+        return true;
     }
 }

--- a/Test/Mftf/Helper/SetSharedSecretOverride.php
+++ b/Test/Mftf/Helper/SetSharedSecretOverride.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkShust\DisableTwoFactorAuth\Test\Mftf\Helper;
+
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
+use Magento\FunctionalTestingFramework\Helper\Helper;
+use Magento\FunctionalTestingFramework\Module\MagentoWebDriver;
+
+class SetSharedSecretOverride extends Helper
+{
+    /**
+     * Set the shared secret if appropriate
+     *
+     * @param string $username
+     */
+    /**
+     * Set the shared secret if appropriate
+     *
+     * @param string $username
+     */
+    public function execute(string $username): void
+    {
+        /** @var MagentoWebDriver $webDriver */
+        $webDriver       = $this->getModule('\\' . MagentoWebDriver::class);
+        $credentialStore = CredentialStore::getInstance();
+        if ($username !== getenv('MAGENTO_ADMIN_USERNAME')) {
+            $sharedSecret = $credentialStore->decryptSecretValue(
+                $credentialStore->getSecret('magento/tfa/OTP_SHARED_SECRET')
+            );
+            if (!$this->checkIfTwoFactorIsEnabled($webDriver)) {
+                return;
+            }
+            try {
+                $webDriver->magentoCLI(
+                    'security:tfa:google:set-secret ' . $username . ' ' . $sharedSecret
+                );
+            } catch (\Throwable $exception) {
+                // Some tests intentionally use bad credentials.
+            }
+        }
+    }
+
+    /**
+     * @param MagentoWebDriver $webDriver
+     */
+    private function checkIfTwoFactorIsEnabled(MagentoWebDriver $webDriver): bool
+    {
+        try {
+            $tfaEnabled = (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
+        } catch (TestFrameworkException $exception) {
+            $tfaEnabled = false;
+        }
+    }
+}

--- a/Test/Mftf/Helper/SetSharedSecretOverride.php
+++ b/Test/Mftf/Helper/SetSharedSecretOverride.php
@@ -52,6 +52,10 @@ class SetSharedSecretOverride extends Helper
             $tfaEnabled = (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
         } catch (TestFrameworkException $exception) {
             $tfaEnabled = false;
+
+            return $tfaEnabled;
         }
+
+        return true;
     }
 }

--- a/Test/Mftf/Helper/SetSharedSecretOverride.php
+++ b/Test/Mftf/Helper/SetSharedSecretOverride.php
@@ -49,13 +49,11 @@ class SetSharedSecretOverride extends Helper
     private function checkIfTwoFactorIsEnabled(MagentoWebDriver $webDriver): bool
     {
         try {
-            $tfaEnabled = (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
+            return (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
         } catch (TestFrameworkException $exception) {
-            $tfaEnabled = false;
 
-            return $tfaEnabled;
+            return false;
         }
 
-        return true;
     }
 }


### PR DESCRIPTION
These changes are added to take care of the MFTF tests. 

When 2FA is disabled, checking for the configuration in the CLI or in the tests will throw an exception.

This happens when the value is set to 0. When 2FA is enabled, running `bin/magento config:show twofactorauth/general/enable`  will return 1, where as when its disabled it will return an exception which we use as an indicator to know that 2FA is disabled and that we should bypass the filling of the OTP key. 

In this case, rewriting the action group and its helper classes is necessary because all helper classes must extend `Magento\FunctionalTestingFramework\Helper\Helper`