### PR TITLE
Removed newline character from MFTF config:show bool cast

### DIFF
--- a/Test/Mftf/Helper/FillOtpOverride.php
+++ b/Test/Mftf/Helper/FillOtpOverride.php
@@ -43,7 +43,7 @@ class FillOtpOverride extends Helper
     private function checkIfTwoFactorIsEnabled(MagentoWebDriver $webDriver): bool
     {
         try {
-            return (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
+            return (bool)str_replace(PHP_EOL, '', $webDriver->magentoCLI('config:show twofactorauth/general/enable'));
         } catch (TestFrameworkException $exception) {
 
             return false;

--- a/Test/Mftf/Helper/SetSharedSecretOverride.php
+++ b/Test/Mftf/Helper/SetSharedSecretOverride.php
@@ -49,7 +49,7 @@ class SetSharedSecretOverride extends Helper
     private function checkIfTwoFactorIsEnabled(MagentoWebDriver $webDriver): bool
     {
         try {
-            return (bool)$webDriver->magentoCLI('config:show twofactorauth/general/enable');
+            return (bool)str_replace(PHP_EOL, '', $webDriver->magentoCLI('config:show twofactorauth/general/enable'));
         } catch (TestFrameworkException $exception) {
 
             return false;


### PR DESCRIPTION
```php
$webDriver->magentoCLI('config:show twofactorauth/general/enable')
```

If 2FA disabled, it returns "0\n" after cast to bool it gives true causing MFTF tests failure.

```
>>> (bool) "0"
=> false
>>> (bool) "0\n"
=> true
```

Simple replace should do the trick.