### PR TITLE
Fix compatibility with MFTF 3.10.0

### DIFF
--- a/Test/Mftf/Helper/FillOtpOverride.php
+++ b/Test/Mftf/Helper/FillOtpOverride.php
@@ -43,7 +43,12 @@ class FillOtpOverride extends Helper
     private function checkIfTwoFactorIsEnabled(MagentoWebDriver $webDriver): bool
     {
         try {
-            return (bool)str_replace(PHP_EOL, '', $webDriver->magentoCLI('config:show twofactorauth/general/enable'));
+            $cliResult = $webDriver->magentoCLI('config:show twofactorauth/general/enable');
+            if ($cliResult === 'CLI did not return output.') {
+                return false;
+            }
+
+            return (bool)str_replace(PHP_EOL, '', $cliResult);
         } catch (TestFrameworkException $exception) {
 
             return false;


### PR DESCRIPTION
MFTF 3.10.0 changed the behaviour of `\Magento\FunctionalTestingFramework\Module\MagentoWebDriver::magentoCLI`: When no output is returned in the CLI, the method now returns the string "CLI did not return output.". This was introduced in https://github.com/magento/magento2-functional-testing-framework/commit/fe04f75ccc9d8e6ba6a305cc8d7ff42bf31de59e. However, a non-empty string is obviously `true` when casted to a `bool`, so that we currently return a wrong result from `\MarkShust\DisableTwoFactorAuth\Test\Mftf\Helper\FillOtpOverride::checkIfTwoFactorIsEnabled`. This breaks the MFTF backend login and my PR fixes this.